### PR TITLE
chore: enable react compiler and tighten types

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -2,8 +2,8 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   experimental: {
-    // Enhanced Suspense support
-    reactCompiler: false, // Will enable when stable
+    // Enable the React Compiler (stable in React 19)
+    reactCompiler: true,
     // Enable optimized package imports
     optimizePackageImports: ['@livekit/components-react', 'lucide-react'],
   },

--- a/src/app/(camera)/camera/[eventId]/page.tsx
+++ b/src/app/(camera)/camera/[eventId]/page.tsx
@@ -1,4 +1,4 @@
-import { Metadata } from "next";
+import type { Metadata } from "next";
 import { notFound, redirect } from "next/navigation";
 import { after } from 'next/server';
 import { EventService } from "@/lib/database";

--- a/src/app/(camera)/camera/join/page.tsx
+++ b/src/app/(camera)/camera/join/page.tsx
@@ -1,4 +1,4 @@
-import { Metadata } from 'next';
+import type { Metadata } from 'next';
 import { Suspense } from 'react';
 import { CameraJoinForm } from '@/components/camera/CameraJoinForm';
 import { Card, CardContent } from '@/components/ui/card';

--- a/src/app/(organizer)/events/[eventId]/dashboard/page.tsx
+++ b/src/app/(organizer)/events/[eventId]/dashboard/page.tsx
@@ -1,4 +1,4 @@
-import { Metadata } from 'next';
+import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { headers } from 'next/headers';
 import { after } from 'next/server';

--- a/src/app/(organizer)/events/create/page.tsx
+++ b/src/app/(organizer)/events/create/page.tsx
@@ -1,4 +1,4 @@
-import { Metadata } from 'next';
+import type { Metadata } from 'next';
 import { EventCreationForm } from '@/components/events/EventCreationForm';
 
 // Next.js 15: 静的ルート最適化のためのdynamic設定

--- a/src/app/(organizer)/events/page.tsx
+++ b/src/app/(organizer)/events/page.tsx
@@ -1,4 +1,4 @@
-import { Metadata } from 'next';
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import { EventService } from '@/lib/database';
 import { Button } from '@/components/ui/button';

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React from "react";
+import Link from "next/link";
 
 export default function GlobalError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
   return (
@@ -15,7 +15,9 @@ export default function GlobalError({ error, reset }: { error: Error & { digest?
         )}
         <div className="flex justify-center gap-2">
           <button type="button" onClick={() => reset()} className="px-4 py-2 rounded-md border">再試行</button>
-          <a href="/" className="px-4 py-2 rounded-md border">ホームに戻る</a>
+          <Link href="/" className="px-4 py-2 rounded-md border">
+            ホームに戻る
+          </Link>
         </div>
         {error.digest && (
           <p className="text-xs text-muted-foreground">エラーID: {error.digest}</p>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata, Viewport } from 'next';
+import type { ReactNode } from 'react';
 import { Inter } from 'next/font/google';
 import { after } from 'next/server';
 import './globals.css';
@@ -39,7 +40,7 @@ import { AppInitializer } from '@/components/AppInitializer';
 export default function RootLayout({
   children,
 }: {
-  children: React.ReactNode;
+  children: ReactNode;
 }) {
   // after() APIを使用してアプリケーション初期化ログを応答後に記録
   after(async () => {

--- a/src/components/auth/AdminLoginForm.tsx
+++ b/src/components/auth/AdminLoginForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import type { FormEvent, ReactNode } from 'react';
 import { useAuth } from '@/hooks/useAuth';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -19,7 +20,7 @@ export function AdminLoginForm({ onSuccess, eventId }: AdminLoginFormProps) {
   const [adminKey, setAdminKey] = useState('');
   const [localError, setLocalError] = useState<string | null>(null);
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     setLocalError(null);
 
@@ -102,9 +103,9 @@ export function AdminLoginForm({ onSuccess, eventId }: AdminLoginFormProps) {
 
 // Protected admin route wrapper
 interface AdminRouteProps {
-  children: React.ReactNode;
+  children: ReactNode;
   eventId?: string;
-  fallback?: React.ReactNode;
+  fallback?: ReactNode;
 }
 
 export function AdminRoute({ children, eventId, fallback }: AdminRouteProps) {

--- a/src/components/camera/CameraStreamInterface.tsx
+++ b/src/components/camera/CameraStreamInterface.tsx
@@ -52,6 +52,9 @@ import {
   Loader2,
 } from "lucide-react";
 
+const ERROR_VIDEO_TRACK_NOT_FOUND = "Video track not found";
+const ERROR_AUDIO_TRACK_NOT_FOUND = "Audio track not found";
+
 interface CameraStreamInterfaceProps {
   roomToken: string;
   roomName: string;

--- a/src/components/error/ErrorBoundary.tsx
+++ b/src/components/error/ErrorBoundary.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import React, { Component, ErrorInfo, ReactNode } from "react";
+import { Component } from "react";
+import type { ErrorInfo, ReactNode } from "react";
 import { isErrorInfo } from '@/lib/type-guards';
 import {
   Card,
@@ -46,7 +47,7 @@ export class ErrorBoundary extends Component<Props, State> {
     };
   }
 
-  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+  override componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     // React 19.1.0の強化されたエラー情報を活用
     console.error("ErrorBoundary caught an error:", error, errorInfo);
 
@@ -108,7 +109,7 @@ export class ErrorBoundary extends Component<Props, State> {
     window.location.href = "/";
   };
 
-  render() {
+  override render() {
     if (this.state.hasError) {
       // カスタムフォールバックUIが提供されている場合
       if (this.props.fallback) {

--- a/src/components/error/ErrorBoundaryClient.tsx
+++ b/src/components/error/ErrorBoundaryClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import React, { ErrorInfo, ReactNode, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
+import type { ErrorInfo, ReactNode } from "react";
 import { ErrorBoundary } from "@/components/error/ErrorBoundary";
 
 type Props = {

--- a/src/components/lazy/LazyComponents.tsx
+++ b/src/components/lazy/LazyComponents.tsx
@@ -2,6 +2,7 @@
 
 import dynamic from 'next/dynamic';
 import { Suspense } from 'react';
+import type { ReactNode } from 'react';
 import { Loader2 } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
 
@@ -75,12 +76,12 @@ export const LazyEventCreationForm = dynamic(
 );
 
 // Wrapper component with Suspense boundary
-export function LazyComponentWrapper({ 
-  children, 
-  fallback 
-}: { 
-  children: React.ReactNode;
-  fallback?: React.ReactNode;
+export function LazyComponentWrapper({
+  children,
+  fallback
+}: {
+  children: ReactNode;
+  fallback?: ReactNode;
 }) {
   return (
     <Suspense fallback={fallback || <ComponentLoader />}>

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,7 +1,7 @@
-import * as React from "react"
-import { cva, type VariantProps } from "class-variance-authority"
+import type { ComponentProps } from "react";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const alertVariants = cva(
   "relative w-full rounded-lg border px-4 py-3 text-sm grid has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] grid-cols-[0_1fr] has-[>svg]:gap-x-3 gap-y-0.5 items-start [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current",
@@ -23,7 +23,7 @@ function Alert({
   className,
   variant,
   ...props
-}: React.ComponentProps<"div"> & VariantProps<typeof alertVariants>) {
+}: ComponentProps<"div"> & VariantProps<typeof alertVariants>) {
   return (
     <div
       data-slot="alert"
@@ -34,7 +34,7 @@ function Alert({
   )
 }
 
-function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
+function AlertTitle({ className, ...props }: ComponentProps<"div">) {
   return (
     <div
       data-slot="alert-title"
@@ -50,7 +50,7 @@ function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
 function AlertDescription({
   className,
   ...props
-}: React.ComponentProps<"div">) {
+}: ComponentProps<"div">) {
   return (
     <div
       data-slot="alert-description"

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,8 +1,8 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
+import type { ComponentProps } from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
   "inline-flex items-center justify-center rounded-md border px-2 py-0.5 text-xs font-medium w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1 [&>svg]:pointer-events-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive transition-[color,box-shadow] overflow-hidden",
@@ -30,7 +30,7 @@ function Badge({
   variant,
   asChild = false,
   ...props
-}: React.ComponentProps<"span"> &
+}: ComponentProps<"span"> &
   VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
   const Comp = asChild ? Slot : "span"
 

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,8 +1,8 @@
-import * as React from "react"
-import { Slot } from "@radix-ui/react-slot"
-import { cva, type VariantProps } from "class-variance-authority"
+import type { ComponentPropsWithRef } from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
@@ -42,7 +42,7 @@ function Button({
   size,
   asChild = false,
   ...props
-}: React.ComponentPropsWithRef<"button"> &
+}: ComponentPropsWithRef<"button"> &
   VariantProps<typeof buttonVariants> & {
     asChild?: boolean
   }) {

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,8 +1,8 @@
-import * as React from "react"
+import type { ComponentProps } from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
-function Card({ className, ...props }: React.ComponentProps<"div">) {
+function Card({ className, ...props }: ComponentProps<"div">) {
   return (
     <div
       data-slot="card"
@@ -15,7 +15,7 @@ function Card({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+function CardHeader({ className, ...props }: ComponentProps<"div">) {
   return (
     <div
       data-slot="card-header"
@@ -28,7 +28,7 @@ function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+function CardTitle({ className, ...props }: ComponentProps<"div">) {
   return (
     <div
       data-slot="card-title"
@@ -38,7 +38,7 @@ function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+function CardDescription({ className, ...props }: ComponentProps<"div">) {
   return (
     <div
       data-slot="card-description"
@@ -48,7 +48,7 @@ function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+function CardAction({ className, ...props }: ComponentProps<"div">) {
   return (
     <div
       data-slot="card-action"
@@ -61,7 +61,7 @@ function CardAction({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+function CardContent({ className, ...props }: ComponentProps<"div">) {
   return (
     <div
       data-slot="card-content"
@@ -71,7 +71,7 @@ function CardContent({ className, ...props }: React.ComponentProps<"div">) {
   )
 }
 
-function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+function CardFooter({ className, ...props }: ComponentProps<"div">) {
   return (
     <div
       data-slot="card-footer"

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -1,8 +1,9 @@
 "use client"
 
-import * as React from "react"
-import * as LabelPrimitive from "@radix-ui/react-label"
-import { Slot } from "@radix-ui/react-slot"
+import { createContext, useContext, useId } from "react";
+import type { ComponentProps } from "react";
+import * as LabelPrimitive from "@radix-ui/react-label";
+import { Slot } from "@radix-ui/react-slot";
 import {
   Controller,
   FormProvider,
@@ -11,10 +12,10 @@ import {
   type ControllerProps,
   type FieldPath,
   type FieldValues,
-} from "react-hook-form"
+} from "react-hook-form";
 
-import { cn } from "@/lib/utils"
-import { Label } from "@/components/ui/label"
+import { cn } from "@/lib/utils";
+import { Label } from "@/components/ui/label";
 
 const Form = FormProvider
 
@@ -25,7 +26,7 @@ type FormFieldContextValue<
   name: TName
 }
 
-const FormFieldContext = React.createContext<FormFieldContextValue>(
+const FormFieldContext = createContext<FormFieldContextValue>(
   {} as FormFieldContextValue
 )
 
@@ -43,8 +44,8 @@ const FormField = <
 }
 
 const useFormField = () => {
-  const fieldContext = React.useContext(FormFieldContext)
-  const itemContext = React.useContext(FormItemContext)
+  const fieldContext = useContext(FormFieldContext)
+  const itemContext = useContext(FormItemContext)
   const { getFieldState } = useFormContext()
   const formState = useFormState({ name: fieldContext.name })
   const fieldState = getFieldState(fieldContext.name, formState)
@@ -69,12 +70,12 @@ type FormItemContextValue = {
   id: string
 }
 
-const FormItemContext = React.createContext<FormItemContextValue>(
+const FormItemContext = createContext<FormItemContextValue>(
   {} as FormItemContextValue
 )
 
-function FormItem({ className, ...props }: React.ComponentProps<"div">) {
-  const id = React.useId()
+function FormItem({ className, ...props }: ComponentProps<"div">) {
+  const id = useId()
 
   return (
     <FormItemContext value={{ id }}>
@@ -90,7 +91,7 @@ function FormItem({ className, ...props }: React.ComponentProps<"div">) {
 function FormLabel({
   className,
   ...props
-}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+}: ComponentProps<typeof LabelPrimitive.Root>) {
   const { error, formItemId } = useFormField()
 
   return (
@@ -104,7 +105,7 @@ function FormLabel({
   )
 }
 
-function FormControl({ ...props }: React.ComponentProps<typeof Slot>) {
+function FormControl({ ...props }: ComponentProps<typeof Slot>) {
   const { error, formItemId, formDescriptionId, formMessageId } = useFormField()
 
   return (
@@ -122,7 +123,7 @@ function FormControl({ ...props }: React.ComponentProps<typeof Slot>) {
   )
 }
 
-function FormDescription({ className, ...props }: React.ComponentProps<"p">) {
+function FormDescription({ className, ...props }: ComponentProps<"p">) {
   const { formDescriptionId } = useFormField()
 
   return (
@@ -135,7 +136,7 @@ function FormDescription({ className, ...props }: React.ComponentProps<"p">) {
   )
 }
 
-function FormMessage({ className, ...props }: React.ComponentProps<"p">) {
+function FormMessage({ className, ...props }: ComponentProps<"p">) {
   const { error, formMessageId } = useFormField()
   const body = error ? String(error?.message ?? "") : props.children
 

--- a/src/components/ui/input-field.tsx
+++ b/src/components/ui/input-field.tsx
@@ -1,12 +1,13 @@
-import * as React from "react"
-import { Input } from "./input"
-import { Label } from "./label"
-import { cn } from "@/lib/utils"
+import { useId } from "react";
+import type { ComponentPropsWithRef, ReactNode } from "react";
+import { Input } from "./input";
+import { Label } from "./label";
+import { cn } from "@/lib/utils";
 
 // React 19: ComponentPropsWithRefを使用したカスタムInputFieldコンポーネント
 // forwardRefを使用せずに、refを通常のpropsとして受け取る
-interface InputFieldProps extends React.ComponentPropsWithRef<"input"> {
-  label?: React.ReactNode
+interface InputFieldProps extends ComponentPropsWithRef<"input"> {
+  label?: ReactNode
   error?: string
   helperText?: string
   containerClassName?: string
@@ -22,7 +23,7 @@ function InputField({
   ...props
 }: InputFieldProps) {
   // React 19: useIdを常に呼び出し、idが指定されている場合はそれを優先
-  const generatedId = React.useId()
+  const generatedId = useId()
   const inputId = id || generatedId
 
   return (

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,9 +1,9 @@
-import * as React from "react"
+import type { ComponentPropsWithRef } from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 // React 19: ComponentPropsWithRefを使用してref as propパターンを明示的に実装
-function Input({ className, type, ...props }: React.ComponentPropsWithRef<"input">) {
+function Input({ className, type, ...props }: ComponentPropsWithRef<"input">) {
   return (
     <input
       type={type}

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,14 +1,14 @@
 "use client"
 
-import * as React from "react"
-import * as LabelPrimitive from "@radix-ui/react-label"
+import type { ComponentProps } from "react";
+import * as LabelPrimitive from "@radix-ui/react-label";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Label({
   className,
   ...props
-}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+}: ComponentProps<typeof LabelPrimitive.Root>) {
   return (
     <LabelPrimitive.Root
       data-slot="label"

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,15 +1,15 @@
 "use client"
 
-import * as React from "react"
-import * as ProgressPrimitive from "@radix-ui/react-progress"
+import type { ComponentProps } from "react";
+import * as ProgressPrimitive from "@radix-ui/react-progress";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Progress({
   className,
   value,
   ...props
-}: React.ComponentProps<typeof ProgressPrimitive.Root>) {
+}: ComponentProps<typeof ProgressPrimitive.Root>) {
   return (
     <ProgressPrimitive.Root
       data-slot="progress"

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,14 +1,14 @@
 "use client"
 
-import * as React from "react"
-import * as TabsPrimitive from "@radix-ui/react-tabs"
+import type { ComponentProps } from "react";
+import * as TabsPrimitive from "@radix-ui/react-tabs";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 function Tabs({
   className,
   ...props
-}: React.ComponentProps<typeof TabsPrimitive.Root>) {
+}: ComponentProps<typeof TabsPrimitive.Root>) {
   return (
     <TabsPrimitive.Root
       data-slot="tabs"
@@ -21,7 +21,7 @@ function Tabs({
 function TabsList({
   className,
   ...props
-}: React.ComponentProps<typeof TabsPrimitive.List>) {
+}: ComponentProps<typeof TabsPrimitive.List>) {
   return (
     <TabsPrimitive.List
       data-slot="tabs-list"
@@ -37,7 +37,7 @@ function TabsList({
 function TabsTrigger({
   className,
   ...props
-}: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+}: ComponentProps<typeof TabsPrimitive.Trigger>) {
   return (
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
@@ -53,7 +53,7 @@ function TabsTrigger({
 function TabsContent({
   className,
   ...props
-}: React.ComponentProps<typeof TabsPrimitive.Content>) {
+}: ComponentProps<typeof TabsPrimitive.Content>) {
   return (
     <TabsPrimitive.Content
       data-slot="tabs-content"

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,9 +1,9 @@
-import * as React from "react"
+import type { ComponentPropsWithRef } from "react";
 
-import { cn } from "@/lib/utils"
+import { cn } from "@/lib/utils";
 
 // React 19: ComponentPropsWithRefを使用してref as propパターンを明示的に実装
-function Textarea({ className, ...props }: React.ComponentPropsWithRef<"textarea">) {
+function Textarea({ className, ...props }: ComponentPropsWithRef<"textarea">) {
   return (
     <textarea
       data-slot="textarea"

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import * as React from 'react';
 import { createContext, useContext, useState, useCallback } from 'react';
+import type { ReactNode } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import {
@@ -33,7 +33,7 @@ interface ToastContextType {
 
 const ToastContext = createContext<ToastContextType | undefined>(undefined);
 
-export function ToastProvider({ children }: { children: React.ReactNode }) {
+export function ToastProvider({ children }: { children: ReactNode }) {
   const [toasts, setToasts] = useState<Toast[]>([]);
 
   const removeToast = useCallback((id: string) => {

--- a/src/components/ui/video.tsx
+++ b/src/components/ui/video.tsx
@@ -1,7 +1,7 @@
-import * as React from "react"
+import type { ComponentPropsWithRef } from "react";
 
-import { cn } from "@/lib/utils"
-import { hasTransformStyle, type VideoStyleProps } from "@/lib/type-guards"
+import { cn } from "@/lib/utils";
+import { hasTransformStyle, type VideoStyleProps } from "@/lib/type-guards";
 
 // React 19: ComponentPropsWithRefを使用したref as propパターンの実装例
 // forwardRefを使用せずに、refを通常のpropsとして受け取る
@@ -13,7 +13,7 @@ function Video({
   // 追加: プレビュー用に水平反転するかどうかを選べるフラグ
   mirror = false,
   ...props
-}: React.ComponentPropsWithRef<"video"> & { mirror?: boolean }) {
+}: ComponentPropsWithRef<"video"> & { mirror?: boolean }) {
   return (
     <video
       data-slot="video"

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useCallback, createContext, useContext, ReactNode, useSyncExternalStore } from 'react';
+import { useEffect, useCallback, createContext, useContext, useSyncExternalStore } from 'react';
+import type { ReactNode } from 'react';
 
 // Authentication types
 export interface AuthUser {

--- a/src/lib/livekit.ts
+++ b/src/lib/livekit.ts
@@ -1,4 +1,5 @@
-import { Room, RoomOptions, VideoPresets } from 'livekit-client';
+import { Room, VideoPresets } from 'livekit-client';
+import type { RoomOptions } from 'livekit-client';
 import { AccessToken } from 'livekit-server-sdk';
 
 // LiveKit client configuration

--- a/src/lib/websocket.ts
+++ b/src/lib/websocket.ts
@@ -235,10 +235,12 @@ export class WebSocketEventHandler {
 
         if (otherActiveCameras.length > 0) {
           // Switch to the most recently joined active camera
-          const newActiveCamera = otherActiveCameras.sort(
-            (a, b) =>
-              new Date(b.joinedAt).getTime() - new Date(a.joinedAt).getTime()
-          )[0];
+          const newActiveCamera =
+            otherActiveCameras.sort(
+              (a, b) =>
+                new Date(b.joinedAt).getTime() -
+                new Date(a.joinedAt).getTime()
+            )[0]!;
 
           
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,9 +18,10 @@
     "isolatedModules": true,
     "jsx": "preserve",
     "incremental": true,
-    "verbatimModuleSyntax": false,
+    "verbatimModuleSyntax": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": false,
+    "noImplicitOverride": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "plugins": [


### PR DESCRIPTION
## Summary
- enable the React Compiler in Next.js
- strengthen type checking and clean up error handling
- use Next.js Link in the global error page
- enable verbatim module syntax and convert type-only imports to `import type`

## Testing
- `pnpm type-check`
- `pnpm lint`
- `pnpm test` *(fails: QRCodeGenerator tests)*

------
https://chatgpt.com/codex/tasks/task_e_688f31c40a288325b7bd65a2ec9edc35